### PR TITLE
chore: update dependencies and workflows, bump to 0.2.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,17 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Render docs
-        uses: docker://pandoc/core:2.19
+        uses: docker://pandoc/core:3.5
         with:
           args: --from gfm --to html5 --output docs/index.html --css docs/style.css --shift-heading-level-by=-1 --embed-resources --standalone Readme.md
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "docs"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - name: Add clippy
         run: rustup component add clippy
@@ -23,6 +23,6 @@ jobs:
     name: format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ jobs:
     name: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - name: Install Rust
         run: rustup toolchain install stable
@@ -23,7 +23,7 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Publish crate
         run: cargo publish --token ${CRATES_TOKEN}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - name: Install Rust
         run: rustup toolchain install stable --component llvm-tools-preview
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: cargo llvm-cov --features 'backend-filesystem' --benches --examples --tests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: lcov.info
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cuttlestore"
 description = "A generic API for interacting with key-value stores that can be selected at runtime."
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Kaan Barmore-Genç <kaan@bgenc.net>"]
 license = "MIT"
@@ -45,7 +45,7 @@ async-stream = "0.3.6"
 serde = { version = "1.0.228", features = ["derive"] }
 # Binary serialization. Both used by the API to encode the payloads, and by some
 # backends internally.
-bincode = "1.3.3"
+bincode = { version = "2.0.1", features = ["serde"] }
 # Generating error types.
 thiserror = "2.0.18"
 # Used to parse connection strings.
@@ -62,27 +62,27 @@ tracing = { version = "0.1", optional = true }
 dashmap = { version = "6.1", optional = true }
 
 # Redis
-redis = { version = "0.22", optional = true, features = [
+redis = { version = "1.2", optional = true, features = [
   "tokio-comp",
   "tokio-native-tls-comp",
 ] }
 # Connection pool for redis
-bb8 = { version = "0.8", optional = true }
-bb8-redis = { version = "0.12", optional = true }
+bb8 = { version = "0.9", optional = true }
+bb8-redis = { version = "0.26", optional = true }
 
 # Sqlite
-sqlx = { version = "0.6", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
   "sqlite",
 ], optional = true }
 
 
 [dev-dependencies]
 # For benchmarks
-criterion = { version = "0.4", features = ["async_tokio"] }
+criterion = { version = "0.8", features = ["async_tokio"] }
 # Generates random data to put into the store during benchmarks
-nanoid = "0.4"
-lipsum = "0.8"
-rand = "0.8"
+nanoid = "0.5"
+lipsum = "0.9"
+rand = "0.10"
 # For easily spawning async stuff in tests
 tokio-test = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cuttlestore"
 description = "A generic API for interacting with key-value stores that can be selected at runtime."
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Kaan Barmore-Genç <kaan@bgenc.net>"]
 license = "MIT"
@@ -32,24 +32,24 @@ sqlite-rustls = ["sqlx/runtime-tokio-rustls"]
 
 [dependencies]
 # For async functions in trait definitions
-async-trait = "0.1.60"
+async-trait = "0.1.89"
 # For streams (async iterators)
-futures = "0.3.25"
+futures = "0.3.32"
 # Async runtime
-tokio = { version = "1.23.1", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 # Built-in for converting Tokio builtins to streams
-tokio-stream = { version = "0.1.11", features = ["fs"] }
+tokio-stream = { version = "0.1.18", features = ["fs"] }
 # Helper macros to generate streams
-async-stream = "0.3.3"
+async-stream = "0.3.6"
 # Serializing data. The API requires stored types to support Serde, but it's also used internally.
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 # Binary serialization. Both used by the API to encode the payloads, and by some
 # backends internally.
 bincode = "1.3.3"
 # Generating error types.
-thiserror = "1.0.38"
+thiserror = "2.0.18"
 # Used to parse connection strings.
-lazy-regex = "2.4.1"
+lazy-regex = "3.6.0"
 # Logging errors
 log = { version = "0.4", optional = true }
 tracing = { version = "0.1", optional = true }
@@ -59,7 +59,7 @@ tracing = { version = "0.1", optional = true }
 #
 
 # Concurrent in-memory key-value storage, for in-memory
-dashmap = { version = "5.4", optional = true }
+dashmap = { version = "6.1", optional = true }
 
 # Redis
 redis = { version = "0.22", optional = true, features = [

--- a/benches/get-concurrent.rs
+++ b/benches/get-concurrent.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use cuttlestore::Cuttlestore;
 use lipsum::lipsum;
-use rand::prelude::Distribution;
+use rand::distr::{Distribution, Uniform};
 use tokio::{runtime, task::JoinHandle};
 
 /// Load the store with values to initialize it.
@@ -25,8 +27,8 @@ async fn load(store: Cuttlestore<String>, count_keys: u64) {
 
 async fn test(store: Cuttlestore<String>, count_keys: u64, checks: u64) {
     let mut tasks: Vec<JoinHandle<()>> = Vec::new();
-    let uniform = rand::distributions::Uniform::new(0, count_keys * 2); // about 50% chance of missing
-    let mut rng = rand::thread_rng();
+    let uniform = Uniform::new(0, count_keys * 2).unwrap(); // about 50% chance of missing
+    let mut rng = rand::rng();
 
     for _ in 0..checks {
         let store = store.clone();

--- a/benches/get-sequential.rs
+++ b/benches/get-sequential.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use cuttlestore::Cuttlestore;
 use lipsum::lipsum;
-use rand::prelude::Distribution;
+use rand::distr::{Distribution, Uniform};
 use tokio::{runtime, task::JoinHandle};
 
 /// Load the store with values to initialize it.
@@ -24,8 +26,8 @@ async fn load(store: Cuttlestore<String>, count_keys: u64) {
 }
 
 async fn test(store: Cuttlestore<String>, count_keys: u64, checks: u64) {
-    let uniform = rand::distributions::Uniform::new(0, count_keys * 2); // about 50% chance of missing
-    let mut rng = rand::thread_rng();
+    let uniform = Uniform::new(0, count_keys * 2).unwrap(); // about 50% chance of missing
+    let mut rng = rand::rng();
     for _ in 0..checks {
         let store = store.clone();
         let key = uniform.sample(&mut rng);

--- a/src/api.rs
+++ b/src/api.rs
@@ -181,7 +181,7 @@ impl<Value: Serialize + DeserializeOwned + Send + Sync> Cuttlestore<Value> {
     /// iterate over values of all stores and discard ones for other stores.
     pub async fn scan(
         &self,
-    ) -> Result<BoxStream<Result<(String, Value), CuttlestoreError>>, CuttlestoreError> {
+    ) -> Result<BoxStream<'_, Result<(String, Value), CuttlestoreError>>, CuttlestoreError> {
         let stream = self.store.scan().await?;
 
         Ok(Box::pin(try_stream! {

--- a/src/api.rs
+++ b/src/api.rs
@@ -146,7 +146,7 @@ impl<Value: Serialize + DeserializeOwned + Send + Sync> Cuttlestore<Value> {
         value: &Value,
         options: PutOptions,
     ) -> Result<(), CuttlestoreError> {
-        let payload = bincode::serialize(value)?;
+        let payload = bincode::serde::encode_to_vec(value, bincode::config::legacy())?;
         self.store
             .put(self.key(key.as_ref()), &payload[..], options)
             .await
@@ -164,7 +164,8 @@ impl<Value: Serialize + DeserializeOwned + Send + Sync> Cuttlestore<Value> {
         let payload = self.store.get(self.key(key.as_ref())).await?;
         let value = payload
             .map(|payload| {
-                let value: Value = bincode::deserialize(&payload[..])?;
+                let (value, _): (Value, _) =
+                    bincode::serde::decode_from_slice(&payload[..], bincode::config::legacy())?;
                 Ok::<Value, CuttlestoreError>(value)
             })
             .transpose()?;
@@ -188,7 +189,8 @@ impl<Value: Serialize + DeserializeOwned + Send + Sync> Cuttlestore<Value> {
             for await pair in stream {
                 let (key, payload) = pair?;
                 if let Some(key) = self.strip_prefix(key) {
-                    let value: Value = bincode::deserialize(&payload[..])?;
+                    let (value, _): (Value, _) =
+                        bincode::serde::decode_from_slice(&payload[..], bincode::config::legacy())?;
 
                     yield (key, value);
                 }

--- a/src/backends/filesystem/mod.rs
+++ b/src/backends/filesystem/mod.rs
@@ -33,8 +33,11 @@ impl FilesystemBackend {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CuttlestoreError> {
         match tokio::fs::read(self.base_folder.join(key)).await {
             Ok(read) => {
-                let value: StoredValue = match bincode::deserialize(&read) {
-                    Ok(val) => val,
+                let value: StoredValue = match bincode::serde::borrow_decode_from_slice(
+                    &read,
+                    bincode::config::legacy(),
+                ) {
+                    Ok((val, _)) => val,
                     Err(err) => {
                         // Decoding failed. This likely suggests data corruption,
                         // such as power loss while file was being written out.
@@ -100,10 +103,13 @@ impl CuttleBackend for FilesystemBackend {
         value: &[u8],
         options: PutOptions,
     ) -> Result<(), CuttlestoreError> {
-        let encoded_value = bincode::serialize(&StoredValue {
-            payload: value,
-            live_until: options.ttl.map(|v| v + get_system_time()),
-        })?;
+        let encoded_value = bincode::serde::encode_to_vec(
+            StoredValue {
+                payload: value,
+                live_until: options.ttl.map(|v| v + get_system_time()),
+            },
+            bincode::config::legacy(),
+        )?;
 
         let mut file = tokio::fs::File::create(self.base_folder.join(key.as_ref())).await?;
         file.write_all(&encoded_value[..]).await?;

--- a/src/backends/redis/mod.rs
+++ b/src/backends/redis/mod.rs
@@ -20,10 +20,16 @@ pub(crate) struct RedisBackend {
 
 impl RedisBackend {
     async fn new(address: &str, args: HashMap<&str, &str>) -> Result<Box<Self>, CuttlestoreError> {
-        let mut info = address.into_connection_info()?;
+        let info = address.into_connection_info()?;
 
-        info.redis.username = args.get("username").map(|v| v.to_string());
-        info.redis.password = args.get("password").map(|v| v.to_string());
+        let mut redis_settings = info.redis_settings().clone();
+        if let Some(username) = args.get("username") {
+            redis_settings = redis_settings.set_username(username);
+        }
+        if let Some(password) = args.get("password") {
+            redis_settings = redis_settings.set_password(password);
+        }
+        let info = info.set_redis_settings(redis_settings);
 
         let manager = RedisConnectionManager::new(info)?;
         let pool = Pool::builder().build(manager).await?;
@@ -74,7 +80,7 @@ impl CuttleBackend for RedisBackend {
         let mut connection = self.pool.get().await?;
 
         if let Some(ttl) = options.ttl {
-            let _: () = connection.set_ex(key.as_ref(), value, ttl as usize).await?;
+            let _: () = connection.set_ex(key.as_ref(), value, ttl).await?;
         } else {
             let _: () = connection.set(key.as_ref(), value).await?;
         }
@@ -144,6 +150,13 @@ impl RedisScanStream {
                     }
                 };
                 if let Some(key) = keys.next_item().await {
+                    let key = match key {
+                        Ok(key) => key,
+                        Err(err) => {
+                            tx.send(Err(err.into())).await.ok();
+                            return;
+                        }
+                    };
                     let value: Result<Option<Vec<u8>>, RedisError> = connection.get(&key).await;
                     match value {
                         Ok(Some(value)) => {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -4,13 +4,19 @@ pub enum CuttlestoreError {
     #[error("No store matching {0} is supported.")]
     NoMatchingBackend(String),
 
-    /// An error occurred when encoding or decoding an object.
+    /// An error occurred when encoding an object.
     ///
-    /// Data is encoded and decoded internally to store objects. An encoding
-    /// error could mean an issue with your application's data types, or it
-    /// could point to data corruption.
-    #[error("Failed to encode or decode data: {0}")]
-    EncodingError(#[from] bincode::Error),
+    /// Data is encoded internally to store objects. An encoding error
+    /// likely means an issue with your application's data types.
+    #[error("Failed to encode data: {0}")]
+    EncodingError(#[from] bincode::error::EncodeError),
+
+    /// An error occurred when decoding an object.
+    ///
+    /// A decoding error could mean an issue with your application's data
+    /// types, or it could point to data corruption.
+    #[error("Failed to decode data: {0}")]
+    DecodingError(#[from] bincode::error::DecodeError),
 
     /// An error happened when accessing the file system.
     ///

--- a/tests/prefix.rs
+++ b/tests/prefix.rs
@@ -26,7 +26,7 @@ async fn test_in_memory() {
 
     assert_eq!(pairs.len(), 1);
     assert_eq!(
-        pairs.get(0).unwrap(),
+        pairs.first().unwrap(),
         &("bar".to_string(), "baz".to_string())
     );
 }

--- a/tests/redis-auth.rs
+++ b/tests/redis-auth.rs
@@ -7,7 +7,7 @@ use tokio::test;
 
 async fn add_user_to_redis() -> (String, String) {
     let redis = redis::Client::open("redis://127.0.0.1").unwrap();
-    let mut conn = redis.get_async_connection().await.unwrap();
+    let mut conn = redis.get_multiplexed_async_connection().await.unwrap();
 
     let user = nanoid::nanoid!();
     let pass = nanoid::nanoid!();
@@ -19,7 +19,9 @@ async fn add_user_to_redis() -> (String, String) {
         Rule::AddPass(pass.clone()),
     ];
 
-    let _: () = conn.acl_setuser_rules(&user, &rules).await.unwrap();
+    conn.acl_setuser_rules::<_, ()>(&user, &rules)
+        .await
+        .unwrap();
 
     (user, pass)
 }

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -80,10 +80,10 @@ pub async fn scan(store: &Cuttlestore<String>) {
 
 pub async fn suite(store: &Cuttlestore<String>) {
     tokio::join!(
-        get_missing(&store),
-        get_then_delete(&store),
-        timeout(&store),
-        overwrite(&store),
-        scan(&store),
+        get_missing(store),
+        get_then_delete(store),
+        timeout(store),
+        overwrite(store),
+        scan(store),
     );
 }


### PR DESCRIPTION
## Summary
Update dependencies (including major bumps), modernize CI workflow actions, and bump crate version to **0.3.0**.

### Dependency upgrades
**Compatible bumps:** `tokio`, `serde`, `futures`, `async-trait`, `tokio-stream`, `async-stream`.

**Major-version bumps:**
- `thiserror` 1 → 2
- `lazy-regex` 2 → 3
- `dashmap` 5 → 6
- `bincode` 1 → 2 (using `serde` feature + `bincode::config::legacy()` to keep the bincode-1 wire format so existing stored data remains readable)
- `redis` 0.22 → 1.2 (new `RedisConnectionInfo` builder API, scan iterator yields `Result`, `set_ex` takes `u64`)
- `bb8` 0.8 → 0.9, `bb8-redis` 0.12 → 0.26
- `sqlx` 0.6 → 0.8
- `rand` 0.8 → 0.10 (`rand::rng()`, fallible `distr::Uniform::new`)
- `criterion` 0.4 → 0.8 (use `std::hint::black_box`)
- `nanoid` 0.4 → 0.5, `lipsum` 0.8 → 0.9

### Workflow updates
- `actions/checkout@v3` → `@v5`
- `codecov/codecov-action@v3` → `@v5`
- `actions/configure-pages@v2` → `@v5`
- `actions/upload-pages-artifact@v1` → `@v3`
- `actions/deploy-pages@v1` → `@v4`
- `pandoc/core:2.19` → `:3.5`

### Code changes
- `CuttlestoreError` now splits `EncodingError` (encode) from `DecodingError` (decode) since bincode 2 has separate error types.
- Fixed `mismatched_lifetime_syntaxes` warning in `src/api.rs` (BoxStream lifetime).
- Fixed `needless_borrow` clippy warnings in tests.
- Updated redis backend for new `ConnectionInfo` builder, scan iterator, and `set_ex` signature.
- Updated bench files for new `rand` and `criterion` APIs.

### Version
Bumped from `0.2.1` to `0.3.0` because `CuttlestoreError` gained a new variant (technically a SemVer break for downstream `match` users, and pre-1.0 minor bumps signal breaking changes).

## Test plan
- [x] `cargo clippy --tests --benches --examples -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test` passes (with redis service, verified in CI)
- [x] Alternative-flag build (`backend-sqlite-rustls`, `--no-default-features`) passes