### PR TITLE
Add DynamoDB backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
         run: cargo test --features 'backend-filesystem' --doc
       - name: Test alternative flags
         # Testing some alternative flag configurations, like rustls and no logging
-        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls' --no-default-features --benches --examples --tests
+        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features --benches --examples --tests
       - name: Run tests
-        run: cargo llvm-cov --features 'backend-filesystem' --benches --examples --tests --lcov --output-path lcov.info
+        run: cargo llvm-cov --features 'backend-filesystem,backend-dynamodb' --benches --examples --tests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -49,3 +49,7 @@ jobs:
         image: redis:7-alpine
         ports:
           - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:2.5.2
+        ports:
+          - 8000:8000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    env:
+      # Avoid stalls from the SDK probing EC2 instance metadata in CI.
+      AWS_EC2_METADATA_DISABLED: "true"
     steps:
       - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
@@ -31,6 +34,17 @@ jobs:
         run: rustup toolchain install stable --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Wait for DynamoDB Local
+        run: |
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/localhost/8000) >/dev/null 2>&1; then
+              echo "DynamoDB Local is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "DynamoDB Local did not become ready in time" >&2
+          exit 1
       - name: Run doc tests
         # llvm-cov has issues with doc tests, so we'll run those separately
         run: cargo test --features 'backend-filesystem' --doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,29 +49,9 @@ jobs:
       - name: Run doc tests
         # llvm-cov has issues with doc tests, so we'll run those separately
         run: cargo test --features 'backend-filesystem' --doc
-      - name: Smoke test DynamoDB Local
-        # An actual API call ensures the service is past JVM warm-up, not just
-        # listening on the port. Catches readiness issues before tests run.
-        run: |
-          for i in $(seq 1 30); do
-            response=$(curl -s -o /dev/null -w "%{http_code}" \
-              -X POST http://localhost:8000/ \
-              -H "Content-Type: application/x-amz-json-1.0" \
-              -H "X-Amz-Target: DynamoDB_20120810.ListTables" \
-              -H "Authorization: AWS4-HMAC-SHA256 Credential=cuttlestore/20260101/us-east-1/dynamodb/aws4_request" \
-              -d '{}' || true)
-            if [ "$response" = "200" ]; then
-              echo "DynamoDB Local responding to API calls"
-              exit 0
-            fi
-            echo "Waiting for DynamoDB Local API (got HTTP $response, attempt $i)..."
-            sleep 1
-          done
-          echo "DynamoDB Local not responding to API calls" >&2
-          exit 1
       - name: Test alternative flags
         # Testing some alternative flag configurations, like rustls and no logging
-        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features --benches --examples --tests -- --nocapture
+        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features --benches --examples --tests
       - name: Run tests
         run: cargo llvm-cov --features 'backend-filesystem,backend-dynamodb' --benches --examples --tests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       # Avoid stalls from the SDK probing EC2 instance metadata in CI.
       AWS_EC2_METADATA_DISABLED: "true"
+      RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
@@ -48,9 +49,29 @@ jobs:
       - name: Run doc tests
         # llvm-cov has issues with doc tests, so we'll run those separately
         run: cargo test --features 'backend-filesystem' --doc
+      - name: Smoke test DynamoDB Local
+        # An actual API call ensures the service is past JVM warm-up, not just
+        # listening on the port. Catches readiness issues before tests run.
+        run: |
+          for i in $(seq 1 30); do
+            response=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST http://localhost:8000/ \
+              -H "Content-Type: application/x-amz-json-1.0" \
+              -H "X-Amz-Target: DynamoDB_20120810.ListTables" \
+              -H "Authorization: AWS4-HMAC-SHA256 Credential=cuttlestore/20260101/us-east-1/dynamodb/aws4_request" \
+              -d '{}' || true)
+            if [ "$response" = "200" ]; then
+              echo "DynamoDB Local responding to API calls"
+              exit 0
+            fi
+            echo "Waiting for DynamoDB Local API (got HTTP $response, attempt $i)..."
+            sleep 1
+          done
+          echo "DynamoDB Local not responding to API calls" >&2
+          exit 1
       - name: Test alternative flags
         # Testing some alternative flag configurations, like rustls and no logging
-        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features --benches --examples --tests
+        run: cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features --benches --examples --tests -- --nocapture
       - name: Run tests
         run: cargo llvm-cov --features 'backend-filesystem,backend-dynamodb' --benches --examples --tests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ backend-redis = ["redis", "bb8", "bb8-redis"]
 backend-filesystem = []
 backend-in-memory = ["dashmap"]
 backend-sqlite = ["backend-sqlite-native-tls"]
+backend-dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-credential-types"]
 logging-tracing = ["tracing"]
 logging-log = ["log"]
 # Backend customization
@@ -74,6 +75,17 @@ bb8-redis = { version = "0.26", optional = true }
 sqlx = { version = "0.8", default-features = false, features = [
   "sqlite",
 ], optional = true }
+
+# DynamoDB
+aws-config = { version = "1.8", optional = true, features = [
+  "behavior-version-latest",
+] }
+aws-sdk-dynamodb = { version = "1", optional = true, features = [
+  "behavior-version-latest",
+] }
+aws-credential-types = { version = "1", optional = true, features = [
+  "hardcoded-credentials",
+] }
 
 
 [dev-dependencies]

--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,7 @@ Cuttlestore currently has support for:
 | Sqlite     | backend-sqlite     | sqlite://path     | An sqlite database used as a key-value store. Best performance if scalability is not a concern. | Yes                |
 | Filesystem | backend-filesystem | filesystem://path | Uses files in a folder as a key-value store. Performance depends on your filesystem.            | No                 |
 | In-Memory  | backend-in-memory  | in-memory         | Not persistent, but very high performance. Useful if the store is ephemeral, like a cache.      | Yes                |
+| DynamoDB   | backend-dynamodb   | dynamodb://region/table | Backed by Amazon DynamoDB. A managed, scalable option that doesn't require running your own server. | No             |
 
 ## Installing
 
@@ -165,6 +166,38 @@ corruption is not expected.
 The ttl feature is supported by periodically scanning the database and deleting
 expired entries on a best-effort basis. This scan uses a Tokio task, meaning it
 will run within your existing Tokio thread pool.
+
+### DynamoDB
+
+Cuttlestore can use Amazon DynamoDB as a backing store. The connection string
+takes the form `dynamodb://<region>/<table>`. The table is automatically
+created if it does not exist, using on-demand (`PAY_PER_REQUEST`) billing, and
+DynamoDB's native TTL feature is enabled on the `live_until` attribute.
+
+For example, to connect to a `cuttlestore` table in `us-east-1`:
+
+```
+dynamodb://us-east-1/cuttlestore
+```
+
+You can supply credentials and a custom endpoint through query string
+parameters: `endpoint`, `access_key`, and `secret_key`. The endpoint is mostly
+useful for pointing at a local DynamoDB instance (such as the official
+[`amazon/dynamodb-local`](https://hub.docker.com/r/amazon/dynamodb-local)
+Docker image) for testing:
+
+```
+dynamodb://us-east-1/cuttlestore-test?endpoint=http://localhost:8000
+```
+
+If `endpoint` is set and no credentials are provided, dummy credentials are
+used (DynamoDB Local ignores them). When connecting to real AWS, omit the
+`endpoint` parameter and credentials will be sourced from the standard AWS
+chain (environment variables, shared profile, IAM role, etc.).
+
+DynamoDB's native TTL deletes expired items on its own schedule, which can
+take up to 48 hours. Cuttlestore additionally filters expired items in `get`
+and `scan` so they are never returned to your application.
 
 #### In-Memory
 

--- a/src/backends/dynamodb/mod.rs
+++ b/src/backends/dynamodb/mod.rs
@@ -20,8 +20,15 @@ use crate::{
     common::{get_system_time, CuttlestoreError},
 };
 
-fn dynamo_err<E: Display>(err: E) -> CuttlestoreError {
-    CuttlestoreError::DynamoDBError(err.to_string())
+fn dynamo_err<E: std::error::Error + 'static>(err: E) -> CuttlestoreError {
+    let mut msg = err.to_string();
+    let mut source: Option<&dyn std::error::Error> = err.source();
+    while let Some(s) = source {
+        msg.push_str(": ");
+        msg.push_str(&s.to_string());
+        source = s.source();
+    }
+    CuttlestoreError::DynamoDBError(msg)
 }
 
 const KEY_ATTR: &str = "key";

--- a/src/backends/dynamodb/mod.rs
+++ b/src/backends/dynamodb/mod.rs
@@ -55,14 +55,15 @@ impl DynamoDBBackend {
                     loader.credentials_provider(Credentials::from_keys(*access, *secret, None));
             }
             _ => {
-                // For DynamoDB Local, the SDK still requires credentials to be
-                // present even though they are ignored by the server. If the
-                // user did not configure any, fall back to test credentials so
-                // local development works without setting AWS_* env vars.
+                // For DynamoDB Local, the SDK still requires credentials to
+                // be present, and the server validates the access key has a
+                // valid AWS format (uppercase alphanumeric). Fall back to a
+                // standard dummy key so local development works without
+                // setting AWS_* env vars.
                 if args.contains_key("endpoint") {
                     loader = loader.credentials_provider(Credentials::from_keys(
-                        "cuttlestore-local",
-                        "cuttlestore-local",
+                        "AKIAIOSFODNN7EXAMPLE",
+                        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                         None,
                     ));
                 }
@@ -70,11 +71,11 @@ impl DynamoDBBackend {
         }
 
         let shared = loader.load().await;
-        // Apply endpoint_url at the DynamoDB client config level so DynamoDB's
-        // account-based endpoint discovery cannot override it. Setting it on
-        // the shared `aws_config` does not always take effect for DynamoDB.
         let mut dynamo_config = aws_sdk_dynamodb::config::Builder::from(&shared);
         if let Some(endpoint) = args.get("endpoint") {
+            // Set endpoint_url on the DynamoDB client config rather than the
+            // shared aws_config, so DynamoDB's endpoint resolver cannot
+            // override it.
             dynamo_config = dynamo_config.endpoint_url(*endpoint);
         }
         let client = Client::from_conf(dynamo_config.build());

--- a/src/backends/dynamodb/mod.rs
+++ b/src/backends/dynamodb/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, fmt::Display};
+use std::{borrow::Cow, collections::HashMap};
 
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -49,10 +49,6 @@ impl DynamoDBBackend {
         let mut loader =
             aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region.to_string()));
 
-        if let Some(endpoint) = args.get("endpoint") {
-            loader = loader.endpoint_url(*endpoint);
-        }
-
         match (args.get("access_key"), args.get("secret_key")) {
             (Some(access), Some(secret)) => {
                 loader =
@@ -73,8 +69,15 @@ impl DynamoDBBackend {
             }
         }
 
-        let config = loader.load().await;
-        let client = Client::new(&config);
+        let shared = loader.load().await;
+        // Apply endpoint_url at the DynamoDB client config level so DynamoDB's
+        // account-based endpoint discovery cannot override it. Setting it on
+        // the shared `aws_config` does not always take effect for DynamoDB.
+        let mut dynamo_config = aws_sdk_dynamodb::config::Builder::from(&shared);
+        if let Some(endpoint) = args.get("endpoint") {
+            dynamo_config = dynamo_config.endpoint_url(*endpoint);
+        }
+        let client = Client::from_conf(dynamo_config.build());
 
         let backend = DynamoDBBackend {
             client,

--- a/src/backends/dynamodb/mod.rs
+++ b/src/backends/dynamodb/mod.rs
@@ -1,0 +1,277 @@
+use std::{borrow::Cow, collections::HashMap, fmt::Display};
+
+use async_stream::try_stream;
+use async_trait::async_trait;
+use aws_config::{BehaviorVersion, Region};
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::{
+    error::SdkError,
+    types::{
+        AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+        ScalarAttributeType, TimeToLiveSpecification,
+    },
+    Client,
+};
+use futures::stream::BoxStream;
+use lazy_regex::regex_captures;
+
+use crate::{
+    backend_api::{CuttleBackend, PutOptions},
+    common::{get_system_time, CuttlestoreError},
+};
+
+fn dynamo_err<E: Display>(err: E) -> CuttlestoreError {
+    CuttlestoreError::DynamoDBError(err.to_string())
+}
+
+const KEY_ATTR: &str = "key";
+const VALUE_ATTR: &str = "value";
+const TTL_ATTR: &str = "live_until";
+
+pub(crate) struct DynamoDBBackend {
+    client: Client,
+    table: String,
+}
+
+impl DynamoDBBackend {
+    async fn new(
+        region: &str,
+        table: &str,
+        args: HashMap<&str, &str>,
+    ) -> Result<Box<Self>, CuttlestoreError> {
+        let mut loader = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(region.to_string()));
+
+        if let Some(endpoint) = args.get("endpoint") {
+            loader = loader.endpoint_url(*endpoint);
+        }
+
+        match (args.get("access_key"), args.get("secret_key")) {
+            (Some(access), Some(secret)) => {
+                loader = loader.credentials_provider(Credentials::from_keys(*access, *secret, None));
+            }
+            _ => {
+                // For DynamoDB Local, the SDK still requires credentials to be
+                // present even though they are ignored by the server. If the
+                // user did not configure any, fall back to test credentials so
+                // local development works without setting AWS_* env vars.
+                if args.contains_key("endpoint") {
+                    loader = loader.credentials_provider(Credentials::from_keys(
+                        "cuttlestore-local",
+                        "cuttlestore-local",
+                        None,
+                    ));
+                }
+            }
+        }
+
+        let config = loader.load().await;
+        let client = Client::new(&config);
+
+        let backend = DynamoDBBackend {
+            client,
+            table: table.to_string(),
+        };
+
+        backend.ensure_table().await?;
+        Ok(Box::new(backend))
+    }
+
+    async fn ensure_table(&self) -> Result<(), CuttlestoreError> {
+        match self
+            .client
+            .describe_table()
+            .table_name(&self.table)
+            .send()
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {}
+            Err(err) => return Err(dynamo_err(err)),
+        };
+
+        self.client
+            .create_table()
+            .table_name(&self.table)
+            .billing_mode(BillingMode::PayPerRequest)
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name(KEY_ATTR)
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .map_err(dynamo_err)?,
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name(KEY_ATTR)
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .map_err(dynamo_err)?,
+            )
+            .send()
+            .await
+            .map_err(dynamo_err)?;
+
+        // Best-effort: enable DynamoDB's native TTL on the live_until
+        // attribute. DynamoDB deletes expired items on its own schedule
+        // (typically within 48 hours), so `get` and `scan` still filter by
+        // `live_until` for correctness.
+        if let Ok(spec) = TimeToLiveSpecification::builder()
+            .attribute_name(TTL_ATTR)
+            .enabled(true)
+            .build()
+        {
+            let _ = self
+                .client
+                .update_time_to_live()
+                .table_name(&self.table)
+                .time_to_live_specification(spec)
+                .send()
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CuttleBackend for DynamoDBBackend {
+    async fn new(conn: &str) -> Option<Result<Box<Self>, CuttlestoreError>> {
+        let (_, region, table, args) =
+            regex_captures!(r#"^dynamodb://([^/]+)/([^?]+)[?]?(.*)"#, conn)?;
+
+        let arg_pairs: HashMap<&str, &str> = args
+            .split('&')
+            .filter(|p| !p.is_empty())
+            .flat_map(|pair| pair.split_once('='))
+            .collect();
+
+        Some(DynamoDBBackend::new(region, table, arg_pairs).await)
+    }
+
+    fn requires_cleaner(&self) -> bool {
+        // DynamoDB has built-in TTL cleanup. We also filter expired items in
+        // `get` and `scan` for correctness, so an external cleaner is not
+        // needed.
+        false
+    }
+
+    fn name(&self) -> &'static str {
+        "dynamodb"
+    }
+
+    async fn get<'a>(&self, key: Cow<'a, str>) -> Result<Option<Vec<u8>>, CuttlestoreError> {
+        let response = self
+            .client
+            .get_item()
+            .table_name(&self.table)
+            .key(KEY_ATTR, AttributeValue::S(key.to_string()))
+            .send()
+            .await
+            .map_err(dynamo_err)?;
+
+        let Some(item) = response.item else {
+            return Ok(None);
+        };
+
+        if let Some(AttributeValue::N(live_until)) = item.get(TTL_ATTR) {
+            if let Ok(live_until) = live_until.parse::<u64>() {
+                if live_until < get_system_time() {
+                    self.delete(key).await?;
+                    return Ok(None);
+                }
+            }
+        }
+
+        match item.get(VALUE_ATTR) {
+            Some(AttributeValue::B(blob)) => Ok(Some(blob.clone().into_inner())),
+            _ => Ok(None),
+        }
+    }
+
+    async fn put<'a>(
+        &self,
+        key: Cow<'a, str>,
+        value: &[u8],
+        options: PutOptions,
+    ) -> Result<(), CuttlestoreError> {
+        let mut request = self
+            .client
+            .put_item()
+            .table_name(&self.table)
+            .item(KEY_ATTR, AttributeValue::S(key.to_string()))
+            .item(
+                VALUE_ATTR,
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(value.to_vec())),
+            );
+
+        if let Some(ttl) = options.ttl {
+            let live_until = get_system_time() + ttl;
+            request = request.item(TTL_ATTR, AttributeValue::N(live_until.to_string()));
+        }
+
+        request.send().await.map_err(dynamo_err)?;
+        Ok(())
+    }
+
+    async fn delete<'a>(&self, key: Cow<'a, str>) -> Result<(), CuttlestoreError> {
+        self.client
+            .delete_item()
+            .table_name(&self.table)
+            .key(KEY_ATTR, AttributeValue::S(key.to_string()))
+            .send()
+            .await
+            .map_err(dynamo_err)?;
+        Ok(())
+    }
+
+    async fn scan(
+        &self,
+    ) -> Result<BoxStream<Result<(String, Vec<u8>), CuttlestoreError>>, CuttlestoreError> {
+        let client = self.client.clone();
+        let table = self.table.clone();
+
+        Ok(Box::pin(try_stream! {
+            let mut last_key: Option<HashMap<String, AttributeValue>> = None;
+            loop {
+                let mut request = client.scan().table_name(&table);
+                if let Some(start) = last_key.take() {
+                    request = request.set_exclusive_start_key(Some(start));
+                }
+                let response = request.send().await.map_err(dynamo_err)?;
+                let now = get_system_time();
+                if let Some(items) = response.items {
+                    for item in items {
+                        let key = match item.get(KEY_ATTR) {
+                            Some(AttributeValue::S(k)) => k.clone(),
+                            _ => continue,
+                        };
+                        if let Some(AttributeValue::N(live_until)) = item.get(TTL_ATTR) {
+                            if let Ok(live_until) = live_until.parse::<u64>() {
+                                if live_until < now {
+                                    client
+                                        .delete_item()
+                                        .table_name(&table)
+                                        .key(KEY_ATTR, AttributeValue::S(key.clone()))
+                                        .send()
+                                        .await
+                                        .map_err(dynamo_err)?;
+                                    continue;
+                                }
+                            }
+                        }
+                        let value = match item.get(VALUE_ATTR) {
+                            Some(AttributeValue::B(blob)) => blob.clone().into_inner(),
+                            _ => continue,
+                        };
+                        yield (key, value);
+                    }
+                }
+                match response.last_evaluated_key {
+                    Some(key) if !key.is_empty() => last_key = Some(key),
+                    _ => break,
+                }
+            }
+        }))
+    }
+}

--- a/src/backends/dynamodb/mod.rs
+++ b/src/backends/dynamodb/mod.rs
@@ -39,8 +39,8 @@ impl DynamoDBBackend {
         table: &str,
         args: HashMap<&str, &str>,
     ) -> Result<Box<Self>, CuttlestoreError> {
-        let mut loader = aws_config::defaults(BehaviorVersion::latest())
-            .region(Region::new(region.to_string()));
+        let mut loader =
+            aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region.to_string()));
 
         if let Some(endpoint) = args.get("endpoint") {
             loader = loader.endpoint_url(*endpoint);
@@ -48,7 +48,8 @@ impl DynamoDBBackend {
 
         match (args.get("access_key"), args.get("secret_key")) {
             (Some(access), Some(secret)) => {
-                loader = loader.credentials_provider(Credentials::from_keys(*access, *secret, None));
+                loader =
+                    loader.credentials_provider(Credentials::from_keys(*access, *secret, None));
             }
             _ => {
                 // For DynamoDB Local, the SDK still requires credentials to be

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -6,3 +6,5 @@ pub(crate) mod in_memory;
 pub(crate) mod redis;
 #[cfg(feature = "backend-sqlite-core")]
 pub(crate) mod sqlite;
+#[cfg(feature = "backend-dynamodb")]
+pub(crate) mod dynamodb;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "backend-dynamodb")]
+pub(crate) mod dynamodb;
 #[cfg(feature = "backend-filesystem")]
 pub(crate) mod filesystem;
 #[cfg(feature = "backend-in-memory")]
@@ -6,5 +8,3 @@ pub(crate) mod in_memory;
 pub(crate) mod redis;
 #[cfg(feature = "backend-sqlite-core")]
 pub(crate) mod sqlite;
-#[cfg(feature = "backend-dynamodb")]
-pub(crate) mod dynamodb;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -182,6 +182,10 @@ pub(crate) async fn find_matching_backend(
     if let Some(backend) = crate::backends::sqlite::SqliteBackend::new(conn).await {
         return Ok(backend?);
     }
+    #[cfg(feature = "backend-dynamodb")]
+    if let Some(backend) = crate::backends::dynamodb::DynamoDBBackend::new(conn).await {
+        return Ok(backend?);
+    }
 
     let maybe_backend = regex_captures!(r#"^([^:]+):"#, conn);
     Err(CuttlestoreError::NoMatchingBackend(

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -40,4 +40,9 @@ pub enum CuttlestoreError {
     #[cfg(feature = "backend-redis")]
     #[error("Failed to connecting to or accessing redis: {0}")]
     RedisConnectionError(#[from] bb8::RunError<redis::RedisError>),
+
+    /// An error happened when accessing DynamoDB.
+    #[cfg(feature = "backend-dynamodb")]
+    #[error("Failed to access DynamoDB: {0}")]
+    DynamoDBError(String),
 }

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -7,7 +7,7 @@ use tokio::test;
 #[test]
 async fn test_dynamodb() {
     let store: Cuttlestore<String> =
-        Cuttlestore::new("dynamodb://us-east-1/cuttlestore-test?endpoint=http://localhost:8000")
+        Cuttlestore::new("dynamodb://us-east-1/cuttlestore-test?endpoint=http://127.0.0.1:8000")
             .await
             .unwrap();
 

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -6,11 +6,10 @@ use tokio::test;
 
 #[test]
 async fn test_dynamodb() {
-    let store: Cuttlestore<String> = Cuttlestore::new(
-        "dynamodb://us-east-1/cuttlestore-test?endpoint=http://localhost:8000",
-    )
-    .await
-    .unwrap();
+    let store: Cuttlestore<String> =
+        Cuttlestore::new("dynamodb://us-east-1/cuttlestore-test?endpoint=http://localhost:8000")
+            .await
+            .unwrap();
 
     suite(&store).await;
 }

--- a/tests/dynamodb.rs
+++ b/tests/dynamodb.rs
@@ -1,0 +1,16 @@
+mod tests;
+use tests::suite;
+
+use cuttlestore::Cuttlestore;
+use tokio::test;
+
+#[test]
+async fn test_dynamodb() {
+    let store: Cuttlestore<String> = Cuttlestore::new(
+        "dynamodb://us-east-1/cuttlestore-test?endpoint=http://localhost:8000",
+    )
+    .await
+    .unwrap();
+
+    suite(&store).await;
+}


### PR DESCRIPTION
## Summary
- Adds a new optional `backend-dynamodb` powered by `aws-sdk-dynamodb`. Connection strings look like `dynamodb://<region>/<table>`, with optional `?endpoint=`, `&access_key=`, `&secret_key=` params.
- Tables are auto-created with on-demand billing, and DynamoDB's native TTL is enabled on the `live_until` attribute. `get` and `scan` also filter expired items so the API contract holds even before DynamoDB's background sweep runs (which can take up to 48h).
- Tests run against an actual backend (no mocks) using the official `amazon/dynamodb-local:2.5.2` Docker image, wired into the existing CI workflow as a service container alongside Redis. LocalStack's free tier is being sunset, so the official AWS image is the safer pick for OSS CI.
- Updates `Readme.md` with a backends table entry and a "DynamoDB" details section following the existing patterns.

Closes #5.

## Test plan
- [x] CI passes with the new `dynamodb` service container
- [x] `cargo test --features 'backend-redis,backend-filesystem,backend-in-memory,backend-sqlite-rustls,backend-dynamodb' --no-default-features` succeeds
- [x] `cargo llvm-cov --features 'backend-filesystem,backend-dynamodb' ...` succeeds
- [x] Doc tests still pass

https://claude.ai/code/session_01LtPrQAZXn2izp2RShy4jsE