### PR TITLE
Default to rustls and enable couchdb backend by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ dashmap = { version = "6.1", optional = true }
 # Redis
 redis = { version = "1.2", optional = true, features = [
   "tokio-comp",
-  "tokio-native-tls-comp",
+  "tokio-rustls-comp",
 ] }
 # Connection pool for redis
 bb8 = { version = "0.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,16 @@ default = [
   "backend-redis",
   "backend-in-memory",
   "backend-sqlite",
+  "backend-dynamodb",
+  "backend-couchdb",
   "logging-tracing",
 ]
 backend-redis = ["redis", "bb8", "bb8-redis"]
 backend-filesystem = []
 backend-in-memory = ["dashmap"]
-backend-sqlite = ["backend-sqlite-native-tls"]
+backend-sqlite = ["backend-sqlite-rustls"]
 backend-dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-credential-types"]
-backend-couchdb = ["backend-couchdb-native-tls"]
+backend-couchdb = ["backend-couchdb-rustls"]
 logging-tracing = ["tracing"]
 logging-log = ["log"]
 # Backend customization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ default = [
   "backend-redis",
   "backend-in-memory",
   "backend-sqlite",
-  "backend-dynamodb",
   "backend-couchdb",
   "logging-tracing",
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -200,6 +200,12 @@ DynamoDB's native TTL deletes expired items on its own schedule, which can
 take up to 48 hours. Cuttlestore additionally filters expired items in `get`
 and `scan` so they are never returned to your application.
 
+Note that enabling `backend-dynamodb` pulls in the AWS SDK (the DynamoDB
+client plus credential-resolution SDKs such as STS and SSO), which can add
+roughly 13 MB to your stripped release binary. For this reason
+`backend-dynamodb` is not part of the default feature set; enable it
+explicitly when you need it.
+
 #### In-Memory
 
 The in-memory backend is a multithreaded in-memory key-value store backed by

--- a/Readme.md
+++ b/Readme.md
@@ -152,7 +152,7 @@ scan uses a Tokio task, meaning it will run within your existing Tokio thread
 pool.
 
 For sqlite, you can enable the feature `backend-sqlite-native-tls` or
-`backend-sqlite-rustls` to pick between native TLS or Rustls. `backend-sqlite` is equal to `backend-sqlite-native-tls`.
+`backend-sqlite-rustls` to pick between native TLS or Rustls. `backend-sqlite` is equal to `backend-sqlite-rustls`.
 
 ### Filesystem
 
@@ -228,7 +228,7 @@ thread pool.
 For CouchDB, you can enable the feature `backend-couchdb-native-tls` or
 `backend-couchdb-rustls` to pick between native TLS or Rustls for the
 underlying HTTP client. `backend-couchdb` is equal to
-`backend-couchdb-native-tls`.
+`backend-couchdb-rustls`.
 
 ## TTL
 


### PR DESCRIPTION
## Summary

- Switch the default TLS implementation for `backend-sqlite`, `backend-couchdb`, and `backend-redis` to rustls, so a stock build no longer needs a system OpenSSL / libssl-dev.
- Enable `backend-couchdb` in the default feature set (pure Rust now that it uses rustls; negligible binary-size cost).
- Leave `backend-dynamodb` opt-in. Enabling it pulls in the AWS SDK (DynamoDB + STS/SSO credential SDKs) and adds ~13 MB to a stripped release binary, which is too much to enable for everyone by default. Documented this in the Readme.

## Binary size check (release + stripped, `examples/basic`)

| Backends enabled | Size |
|---|---|
| redis + in-memory + sqlite + couchdb | 9.25 MB |
| above + dynamodb | 22.30 MB |

Measured with the default release profile (no LTO). With `lto = "fat"` the delta would likely shrink, but it's still a substantial dep, so opt-in is the safer default.

## Notes / trade-offs

- The sqlite/couchdb/redis TLS switches only affect the underlying HTTP/TLS stack (`sqlx` runtime feature, `reqwest` TLS backend, `redis` tokio-tls comp). sqlite itself doesn't even use TLS — the feature just selects which TLS impl `sqlx`'s tokio runtime links against.
- Users who want native-tls can still opt in explicitly via `backend-sqlite-native-tls` / `backend-couchdb-native-tls`. The Readme has been updated to reflect the new defaults.

## Test plan

- [x] `cargo check` with all default backends enabled
- [x] `cargo check` with only redis + rustls comp
- [x] `cargo build --release` size comparison with and without dynamodb
- [x] CI passes
