### PR TITLE
ci: reuse test workflow in release so dynamodb is covered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,44 +2,9 @@ name: release
 on: workflow_dispatch
 jobs:
   tests:
-    name: tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: Swatinem/rust-cache@v2
-      - name: Install Rust
-        run: rustup toolchain install stable
-      - name: Start SurrealDB
-        run: |
-          docker run -d --name surrealdb -p 8001:8000 \
-            surrealdb/surrealdb:v2.3.7 \
-            start --user root --pass root --bind 0.0.0.0:8000 memory
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8001/health >/dev/null 2>&1; then
-              echo "SurrealDB is up"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "SurrealDB did not become ready in time" >&2
-          docker logs surrealdb || true
-          exit 1
-      - name: Run doc tests
-        run: cargo test --features 'backend-filesystem' --doc
-      - name: Run tests
-        run: cargo test --features 'backend-filesystem,backend-couchdb,backend-surrealdb' --benches --examples --tests
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-      couchdb:
-        image: couchdb:3
-        ports:
-          - 5984:5984
-        env:
-          COUCHDB_USER: admin
-          COUCHDB_PASSWORD: password
+    # Reuse the full test workflow so a release is gated on the same backend
+    # matrix (including DynamoDB) that PRs and pushes to main run against.
+    uses: ./.github/workflows/test.yml
   release:
     name: release
     needs: [tests]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
       - tests/*
       - .github/workflows/test.yml
       - Cargo.toml
+  # Allow other workflows (e.g. release.yml) to reuse this test suite so we
+  # never ship a release without running the full backend test matrix.
+  workflow_call:
 jobs:
   test:
     name: test


### PR DESCRIPTION
## Summary
- The release workflow's `tests` job was a hand-maintained copy of `test.yml` that had drifted: it didn't enable `backend-dynamodb` or start a DynamoDB Local service, so `tests/dynamodb.rs` failed during release with `NoMatchingBackend("dynamodb")`.
- Add a `workflow_call:` trigger to `test.yml` and have `release.yml` invoke it via `uses: ./.github/workflows/test.yml`, so releases are always gated on the same backend matrix (including DynamoDB) as PRs and pushes to `main`. No more drift.

## Test plan
- [ ] Trigger the `release` workflow via `workflow_dispatch` on this branch and confirm the reused test job runs the full matrix (redis, dynamodb, couchdb, surrealdb, sqlite, filesystem, in-memory) and passes before the publish step.